### PR TITLE
fix processing of field names with special characters

### DIFF
--- a/packages/nameof_modern/lib/src/nameof_modern_code_processor.dart
+++ b/packages/nameof_modern/lib/src/nameof_modern_code_processor.dart
@@ -23,14 +23,16 @@ class NameofModernCodeProcessor {
   String _generateNames(NameofModernVisitor visitor) {
     StringBuffer buffer = StringBuffer();
 
-    final classContainerName = 'Nameof${visitor.className}';
+
+    final classContainerName =
+        'Nameof${visitor.className.replaceAll(RegExp('[^a-zA-Z0-9]'), '')}';
 
     buffer.writeln(
         '/// Container for names of elements belonging to the [${visitor.className}] class');
     buffer.writeln('abstract class $classContainerName {');
 
     final className =
-        'static const String className = \'${visitor.className}\';';
+        'static const String className = r\'${visitor.className}\';';
 
     final constructorNames =
         _getCodeParts('constructor', visitor.constructors.values);
@@ -40,7 +42,7 @@ class NameofModernCodeProcessor {
     final functionNames = _getCodeParts('function', visitor.functions.values);
 
     final propertyNames = _getFilteredNames(visitor.properties.values).map((prop) =>
-        'static const String property${(prop as PropertyInfo).propertyPrefix}${prop.originalName.capitalize().privatize()} = \'${prop.name}\';');
+        'static const String property${(prop as PropertyInfo).propertyPrefix}${prop.originalName.capitalize().privatize()} = r\'${prop.name}\';');
 
     void writeCode(Iterable<String> codeLines) {
       if (codeLines.isNotEmpty) {
@@ -79,6 +81,6 @@ class NameofModernCodeProcessor {
   Iterable<String> _getCodeParts(
       String elementType, Iterable<ElementInfo> elements) {
     return _getFilteredNames(elements).map((element) =>
-        'static const String $elementType${element.scopePrefix}${element.originalName.capitalize().privatize()} = \'${element.name}\';');
+        'static const String $elementType${element.scopePrefix}${element.originalName.capitalize().privatize()} = r\'${element.name}\';');
   }
 }

--- a/packages/nameof_modern/pubspec.yaml
+++ b/packages/nameof_modern/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nameof_modern
 description: An upgrade modern code of the official and original nameof. Nameof package, that is Generator for  Dart class member's names, such as fields etc...
-version: 0.0.2
+version: 0.0.3
 homepage: https://www.elssiany.com/
 repository: https://github.com/elssiany/nameof_modern
 issue_tracker: https://github.com/elssiany/nameof_modern/issues

--- a/packages/nameof_modern/test/implementation/models.dart
+++ b/packages/nameof_modern/test/implementation/models.dart
@@ -54,3 +54,23 @@ class Movie {
     required this.year,
   });
 }
+
+@nameof
+class _PrivateClass {
+  String privateVariable;
+
+  _PrivateClass({
+    required this.privateVariable,
+  });
+}
+
+@nameof
+class $PublicClass {
+  String publicVariable;
+  String _privateVariable = '';
+  String $publicVariable = '';
+
+  $PublicClass({
+    required this.publicVariable,
+  });
+}

--- a/packages/nameof_modern/test/implementation/models.nameof.dart
+++ b/packages/nameof_modern/test/implementation/models.nameof.dart
@@ -8,41 +8,60 @@ part of 'models.dart';
 
 /// Container for names of elements belonging to the [BaseClass] class
 abstract class NameofBaseClass {
-  static const String className = 'BaseClass';
+  static const String className = r'BaseClass';
 
-  static const String constructor = '';
+  static const String constructor = r'';
 
-  static const String fieldPrice = 'price';
+  static const String fieldPrice = r'price';
 }
 
 /// Container for names of elements belonging to the [ModelOne] class
 abstract class NameofModelOne {
-  static const String className = 'ModelOne';
+  static const String className = r'ModelOne';
 
-  static const String constructor = '';
+  static const String constructor = r'';
 
-  static const String fieldName = 'name';
-  static const String fieldId = 'id';
+  static const String fieldName = r'name';
+  static const String fieldId = r'id';
 
-  static const String propertyGetBehindProp = 'behindProp';
-  static const String propertySetBehindProp = 'behindProp';
+  static const String propertyGetBehindProp = r'behindProp';
+  static const String propertySetBehindProp = r'behindProp';
 
-  static const String functionBuildValue = 'buildValue';
+  static const String functionBuildValue = r'buildValue';
 }
 
 /// Container for names of elements belonging to the [MixinOne] class
 abstract class NameofMixinOne {
-  static const String className = 'MixinOne';
+  static const String className = r'MixinOne';
 
-  static const String propertyGetNameVinage = 'hameleon';
+  static const String propertyGetNameVinage = r'hameleon';
 }
 
 /// Container for names of elements belonging to the [Movie] class
 abstract class NameofMovie {
-  static const String className = 'Movie';
+  static const String className = r'Movie';
 
-  static const String constructor = '';
+  static const String constructor = r'';
 
-  static const String fieldTitle = 'title';
-  static const String fieldDescription = 'description';
+  static const String fieldTitle = r'title';
+  static const String fieldDescription = r'description';
+}
+
+/// Container for names of elements belonging to the [_PrivateClass] class
+abstract class NameofPrivateClass {
+  static const String className = r'_PrivateClass';
+
+  static const String constructor = r'';
+
+  static const String fieldPrivateVariable = r'privateVariable';
+}
+
+/// Container for names of elements belonging to the [$PublicClass] class
+abstract class NameofPublicClass {
+  static const String className = r'$PublicClass';
+
+  static const String constructor = r'';
+
+  static const String fieldPublicVariable = r'publicVariable';
+  static const String field$publicVariable = r'$publicVariable';
 }


### PR DESCRIPTION
i was using this package to generate field names for realm package. to generate a realm entity you must define the class with _ or $ symbols in the name (otherwise the generated realm class will conflict with the skeleton class used for templating).

```
@RealmModel()
class _Foo {
    late String foo;
}

@RealmModel()
class $Bar {
    late String bar;
}
```

this leads to ugly names for the generated classes of Nameof which are not passing the lint
```
Nameof_Foo {}
Nameof$Bar {}
```

as well as the code that cannot be compiled
```
Nameof$Bar {
      static const String className = '$Bar';
}
```

so my fix is pretty simple:
- remove all non-alphanumeric characters in `Nameof%ClassName%` class name
- wrap generated values with `r` to mark string values as raw